### PR TITLE
Fix for Gui launch error.

### DIFF
--- a/Gui.py
+++ b/Gui.py
@@ -225,7 +225,9 @@ def guiMain(args=None):
         if args.seed:
             seedVar.set(str(args.seed))
         bridgeVar.set(args.bridge)
-        colorVars.set([args.kokiricolor, args.goroncolor, args.zoracolor])
+        colorVars[0].set(args.kokiricolor)
+        colorVars[1].set(args.goroncolor)
+        colorVars[2].set(args.zoracolor)
         lowHealthSFXVar.set(args.healthSFX)
         romVar.set(args.rom)
 


### PR DESCRIPTION
Was messing around with the project and noticed the Gui wouldn't launch on the Dev branch due to using .set() on a list. I went ahead and modified Gui.py to fix it so the Gui would launch when OoTRandomizer.py is called with the --gui flag.