### PR TITLE
Race rom option (replaces Generate spoiler log)

### DIFF
--- a/Gui.py
+++ b/Gui.py
@@ -50,8 +50,9 @@ def guiMain(args=None):
     rightHalfFrame = Frame(topFrame)
     checkBoxFrame = Frame(rightHalfFrame)
 
-    createSpoilerVar = IntVar()
-    createSpoilerCheckbutton = Checkbutton(checkBoxFrame, text="Create Spoiler Log (affects item layout)", variable=createSpoilerVar)
+    raceRomVar = IntVar()
+    raceRomCheckbutton = Checkbutton(checkBoxFrame, text="Generate race rom [?]", variable=raceRomVar)
+    ToolTips.register(raceRomCheckbutton, "If this box is checked, a spoiler log will not be generated and items will be placed differently")
     suppressRomVar = IntVar()
     suppressRomCheckbutton = Checkbutton(checkBoxFrame, text="Do not create patched Rom", variable=suppressRomVar)
     compressRomVar = IntVar()
@@ -69,7 +70,7 @@ def guiMain(args=None):
     hintsVar = IntVar()
     hintsCheckbutton = Checkbutton(checkBoxFrame, text="Gossip Stone Hints with Stone of Agony", variable=hintsVar)
 
-    createSpoilerCheckbutton.pack(expand=True, anchor=W)
+    raceRomCheckbutton.pack(expand=True, anchor=W)
     suppressRomCheckbutton.pack(expand=True, anchor=W)
     compressRomCheckbutton.pack(expand=True, anchor=W)
     openForestCheckbutton.pack(expand=True, anchor=W)
@@ -139,13 +140,13 @@ def guiMain(args=None):
 
     lowHealthSFXVar = StringVar()
     lowHealthSFXVar.set('Default')
-    
+
     lowHealthSFXFrame = Frame(dropDownFrame)
     lowHealthSFXOptionMenu = OptionMenu(lowHealthSFXFrame, lowHealthSFXVar, 'Default', 'Softer Beep', 'Rupee', 'Timer', 'Tamborine', 'Recovery Heart', 'Carrot Refill', 'Navi - Hey!', 'Zelda - Gasp', 'Cluck', 'Mweep!', 'Random', 'None')
     lowHealthSFXOptionMenu.pack(side=RIGHT)
     lowHealthSFXLabel = Label(lowHealthSFXFrame, text='Low Health SFX')
     lowHealthSFXLabel.pack(side=LEFT)
-    
+
     bridgeFrame.pack(expand=True, anchor=E)
     kokiriFrame.pack(expand=True, anchor=E)
     goronFrame.pack(expand=True, anchor=E)
@@ -170,7 +171,7 @@ def guiMain(args=None):
         guiargs.goroncolor = colorVars[1].get()
         guiargs.zoracolor = colorVars[2].get()
         guiargs.healthSFX = lowHealthSFXVar.get()
-        guiargs.create_spoiler = bool(createSpoilerVar.get())
+        guiargs.race_rom = bool(raceRomVar.get())
         guiargs.suppress_rom = bool(suppressRomVar.get())
         guiargs.compress_rom = bool(compressRomVar.get())
         guiargs.open_forest = bool(openForestVar.get())
@@ -210,7 +211,7 @@ def guiMain(args=None):
 
     if args is not None:
         # load values from commandline args
-        createSpoilerVar.set(int(args.create_spoiler))
+        raceRomVar.set(int(args.race_rom))
         suppressRomVar.set(int(args.suppress_rom))
         compressRomVar.set(int(args.compress_rom))
         if args.nodungeonitems:

--- a/Main.py
+++ b/Main.py
@@ -31,7 +31,7 @@ def main(args, seed=None):
     else:
         world.seed = int(seed)
     random.seed(world.seed)
-    if args.create_spoiler: # Make game different if spoiler log is generated.
+    if not args.race_rom: # Make game different if spoiler log is not generated.
         for i in range (0, 10): # Generate many random numbers to increase volatility.
             new_base_seed = random.randint(0, 999999999)
         random.seed(new_base_seed)
@@ -88,7 +88,7 @@ def main(args, seed=None):
             else:
                 logger.info('OS not supported for compression')
 
-    if args.create_spoiler:
+    if not args.race_rom:
         world.spoiler.to_file(output_path('%s_Spoiler.txt' % outfilebase))
 
     logger.info('Done. Enjoy.')

--- a/OoTRandomizer.py
+++ b/OoTRandomizer.py
@@ -19,7 +19,7 @@ class ArgumentDefaultsHelpFormatter(argparse.RawTextHelpFormatter):
 
 def start():
     parser = argparse.ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
-    parser.add_argument('--create_spoiler', help='Output a Spoiler File', action='store_true')
+    parser.add_argument('--race_rom', help='Place items differently and do not generate a spoiler', action='store_true')
     parser.add_argument('--bridge', default='medallions', const='medallions', nargs='?', choices=['medallions', 'vanilla', 'dungeons', 'open'],
                         help='''\
                              Select requirement to spawn the Rainbow Bridge to reach Ganon's Castle. (default: %(default)s)

--- a/README.md
+++ b/README.md
@@ -276,10 +276,10 @@ Use to batch generate multiple seeds with same settings. If a seed number is pro
 Show the help message and exit.
 
 ```
---create_spoiler      
+--race_rom      
 ```
 
-Output a Spoiler File (default: False)
+Place items differently and do not generate a spoiler (default: False)
 
 ```
 --bridge [{medallions,vanilla,dungeons,open}]


### PR DESCRIPTION
Mainly an aesthetic change. Race roms can now be generated, which disables the spoiler log and places items differently. Spoiler logs are always generated otherwise. Defaults to false. Tooltip explanation added.