### PR TITLE
Uses ZOOTDEC.z64 in working directory if no ROM is specified

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -74,6 +74,8 @@ def main(args, seed=None):
     outfilebase = 'OoT_%s%s%s%s%s_%s' % (world.bridge, "-openforest" if world.open_forest else "", "-opendoor" if world.open_door_of_time else "", "-fastganon" if world.fast_ganon else "", "-beatableonly" if world.check_beatable_only else "",  world.seed)
 
     if not args.suppress_rom:
+        if not args.rom:
+            args.rom="ZOOTDEC.z64"
         rom = LocalRom(args.rom)
         patch_rom(world, rom)
         rom.write_to_file(output_path('%s.z64' % outfilebase))


### PR DESCRIPTION
Eliminates the need to specify a rom for every seed generation.  First time generation requires vanilla ROM to decompress, subsequent generations will use the decompressed ZOOTDEC.z64 rom if --rom isn't specified or no ROM selected in Gui.py