### PR TITLE
Added --output flag and custom output directory for created ROMs

### DIFF
--- a/Gui.py
+++ b/Gui.py
@@ -95,6 +95,8 @@ def guiMain(args=None):
         else:
             outputDirectory = filedialog.askdirectory(initialdir='.',title='Please select an output directory', mustexist=False)
 
+        #as a minor note, you can define a non-created dir in linux through the filedialog.askdirectory, hence the mustexist flag, but you can't do that in windows. 
+        #just tkinter things.
         dirVar.set(outputDirectory)
     dirSelectButton = Button(topOfBottomFrame, text='Select Dir', command=DirSelect)
 

--- a/Main.py
+++ b/Main.py
@@ -76,11 +76,11 @@ def main(args, seed=None):
     if not args.suppress_rom:
         rom = LocalRom(args.rom)
         patch_rom(world, rom)
-        rom.write_to_file(output_path('%s.z64' % outfilebase))
+        rom.write_to_file(output_path('%s.z64' % outfilebase, args.output))
         if args.compress_rom:
             logger.info('Compressing ROM.')
             if platform.system() == 'Windows':
-                subprocess.call(["Compress\Compress.exe", (output_path('%s.z64' % outfilebase)), (output_path('%s-comp.z64' % outfilebase))])
+                subprocess.call(["Compress\Compress.exe", (output_path('%s.z64' % outfilebase, args.output)), (output_path('%s-comp.z64' % outfilebase, args.output))])
             elif platform.system() == 'Linux':
                 subprocess.call(["Compress/Compress", ('%s.z64' % outfilebase)])
             elif platform.system() == 'Darwin':
@@ -89,7 +89,7 @@ def main(args, seed=None):
                 logger.info('OS not supported for compression')
 
     if args.create_spoiler:
-        world.spoiler.to_file(output_path('%s_Spoiler.txt' % outfilebase))
+        world.spoiler.to_file(output_path('%s_Spoiler.txt' % outfilebase, args.output))
 
     logger.info('Done. Enjoy.')
     logger.debug('Total Time: %s', time.clock() - start)

--- a/OoTRandomizer.py
+++ b/OoTRandomizer.py
@@ -96,6 +96,7 @@ def start():
     parser.add_argument('--suppress_rom', help='Do not create an output rom file.', action='store_true')
     parser.add_argument('--compress_rom', help='Create a compressed version of the output rom file.', action='store_true')
     parser.add_argument('--gui', help='Launch the GUI', action='store_true')
+    parser.add_argument('--output', help='Define Rom output path', default=None, nargs='?')
     args = parser.parse_args()
 
     if is_bundled() and len(sys.argv) == 1:


### PR DESCRIPTION
These changes only apply to the unpackaged version of the randomizer.

Created a --output flag for the main OoTRandomizer.py script call and integrated it into the GUI as well. I went ahead and restructured the GUI slightly to make use of the empty spot below the frame used for all the dropdown menu settings. As part of the restructure of the GUI, I removed the romDialogFrame and split up the bottom frame slightly more. To the end user using the GUI, they won't notice a difference. Also in the GUI, the directory path portion of the GUI only displays if the program is not bundled, as I have not integrated it into the bundled portion. That will take more work and I'll try to tackle that through another PR if this PR gets accepted..

Here is an image of the updated GUI.
![image](https://user-images.githubusercontent.com/11862822/41697116-5ccd9fb0-74e5-11e8-94c7-47060cc85042.png)


Have some logging output for invalid directory paths, when it tries to create a directory path, and if it fails to create the directory path. I have edits from maintainers on if you'd like to remove this, but I feel like it is good. One thing a dev on this project might want to change is the "help" for the --output argument flag, but I just put something there to fulfill that requirement. 

Tested and confirmed working on Windows and Linux. Unable to test on Mac/darwin based machines. Testing and verification of features added included the following:
- Ensuring other calls output_path (like when the decompressed ZOOTDEC ROM is called) all worked properly still.
- Testing all avenues of creating directories, including trying to set the directory to a drive not mapped to the machine.
- Testing directory path setting through both GUI and command line
- In the GUI specifically, testing changes to open the output directory to the defined output directory path. If it fails, it will use the default output directory path.
- If an invalid directory is used across the generation of multiple rando ROMs, then the output_path.invalid_output_arg var is used as a flag so the program does not try to create the directory for each rando ROM it creates.

As a final note, ideally this is just a temporary way to define an output directory path for generate ROMs. I'd like to eventually come up with a way for a settings file so a lot of these settings do not need to be set every time an end user opens the program. Again, will tackle through another PR, probably after I integrate custom output directories into the packaged build. Assuming this one gets accepted.