### PR TITLE
Require Ocarina for Sun's Song Night Skulltula flag

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -395,7 +395,7 @@ class CollectionState(object):
 
     def nighttime(self):
         if self.world.logic_no_night_tokens_without_suns_song:
-            return self.has('Suns Song')
+            return self.can_play('Suns Song')
         return True
 
     def collect(self, item):


### PR DESCRIPTION
This flag verifies that you don't get nighttime skulltulas when you don't have the Sun's Song, but with Ocarina shuffled it doesn't verify that you have an Ocarina.