### PR TITLE
Logic fix for DC in OHKO

### DIFF
--- a/Rules.py
+++ b/Rules.py
@@ -346,6 +346,7 @@ def global_rules(world):
         add_item_rule(location, lambda i: not (i.type == 'Shop' and i.world.id != location.world.id))
         if location.type == 'Shop':
             forbid_item(location, 'Biggoron Sword')
+            forbid_item(location, 'Gold Skulltulla Token')
 
             if location.parent_region.name in ['Castle Town Bombchu Shop', 'Castle Town Potion Shop', 'Castle Town Bazaar']:
                 if not world.check_beatable_only:
@@ -461,11 +462,11 @@ def dung_rules_dcmq(world):
     set_rule(world.get_location('Dodongos Cavern MQ Compass Chest'), lambda state: state.is_adult() or state.can_child_attack() or state.has_nuts())
     set_rule(world.get_location('Dodongos Cavern MQ Torch Puzzle Room Chest'), lambda state: state.can_blast_or_smash() or state.has_sticks() or state.can_use('Dins Fire') or (state.is_adult() and (world.logic_dc_jump or state.has('Hover Boots') or state.has('Progressive Hookshot'))))
     set_rule(world.get_location('Dodongos Cavern MQ Larva Room Chest'), lambda state: (state.has_sticks() and (state.has_explosives() or state.has('Progressive Strength Upgrade'))) or state.has_fire_source())
-    set_rule(world.get_location('Dodongos Cavern MQ Bomb Bag Chest'), lambda state: state.is_adult() or (state.has_slingshot() and (state.has_sticks() or state.can_use('Dins Fire') or state.has_explosives())))
+    set_rule(world.get_location('Dodongos Cavern MQ Bomb Bag Chest'), lambda state: state.is_adult() or (state.has_slingshot() and (state.has_explosives() or ((state.has_sticks() or state.can_use('Dins Fire')) and (world.difficulty != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love'))))))
     set_rule(world.get_location('DC MQ Deku Scrub Deku Sticks'), lambda state: state.can_stun_deku())
     set_rule(world.get_location('DC MQ Deku Scrub Deku Seeds'), lambda state: state.can_stun_deku())
     set_rule(world.get_location('DC MQ Deku Scrub Deku Shield'), lambda state: state.can_stun_deku())
-    set_rule(world.get_location('DC MQ Deku Scrub Red Potion'), lambda state: state.is_adult() or state.has_sticks() or state.can_use('Dins Fire') or state.has_explosives())
+    set_rule(world.get_location('DC MQ Deku Scrub Red Potion'), lambda state: state.is_adult() or state.has_explosives() or ((state.has_sticks() or state.can_use('Dins Fire')) and (world.difficulty != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love'))))
 
     # Boss
     set_rule(world.get_location('King Dodongo'), lambda state: (state.has_bombs() or state.has('Progressive Strength Upgrade')) and (state.is_adult() or state.has_sticks() or state.has('Kokiri Sword')))
@@ -475,7 +476,7 @@ def dung_rules_dcmq(world):
     set_rule(world.get_location('GS Dodongo\'s Cavern MQ Song of Time Block Room'), lambda state: state.can_play('Song of Time') and (state.can_child_attack() or state.is_adult()))
     set_rule(world.get_location('GS Dodongo\'s Cavern MQ Larva Room'), lambda state: (state.has_sticks() and (state.has_explosives or state.has('Progressive Strength Upgrade'))) or state.has_fire_source())
     set_rule(world.get_location('GS Dodongo\'s Cavern MQ Lizalfos Room'), lambda state: state.can_blast_or_smash())
-    set_rule(world.get_location('GS Dodongo\'s Cavern MQ Scrub Room'), lambda state: (state.has('Boomerang') and (state.has_slingshot() or (state.is_adult() and state.has_explosives())) and (state.has_explosives() or (state.has('Progressive Strength Upgrade') and (state.has_sticks() or state.can_use('Dins Fire') or (state.is_adult() and (world.logic_dc_jump or state.has('Hover Boots') or state.has('Hammer'))))))) or (state.can_use('Hookshot') and (state.has_explosives() or state.has('Progressive Strength Upgrade') or state.has_bow() or state.can_use('Dins Fire'))))
+    set_rule(world.get_location('GS Dodongo\'s Cavern MQ Scrub Room'), lambda state: (state.has('Boomerang') and (state.has_slingshot() or (state.is_adult() and state.has_explosives())) and (state.has_explosives() or (state.has('Progressive Strength Upgrade') and (state.can_use('Hammer') or ((state.has_sticks() or state.can_use('Dins Fire') or (state.is_adult() and (world.logic_dc_jump or state.has('Hover Boots')))) and (world.difficulty != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love'))))))) or (state.can_use('Hookshot') and (state.has_explosives() or state.has('Progressive Strength Upgrade') or state.has_bow() or state.can_use('Dins Fire'))))
 
 # Jabu Jabu's Belly Vanilla
 def dung_rules_jb0(world):


### PR DESCRIPTION
So originally I was thinking you would survive the jump down by shield-dropping the bomb flower at the last moment, then rolling out, then picking it back up, and then just barely throwing it in time to blow up the wall. It was pretty hard but at least it saved me from having to account for OHKO in DC.

Then come shopsanity, and now I've have to check for Buy Deku Shield, as well as bottle or Nayru's. And for the one that you could do as adult, Buy Hylian Shield (which would need to be made progressive) and Mirror Shield as well. So I decided using a shield was dumb and hard, and we'll just require bottle (or Nayru's if the minds on excluding that from OHKO ever change).

The adult routes which carry the flower down, there's an alternative where you can backwalk with a bombflower out through the one-sided collision of the bombable wall and blow it up that way. I decided that, though that wasn't hard, it was too glitch-like to required in this case.

This includes TR's change to ban tokens from shops, but does not include my logic_tricks additions, which would have to be merged separately.