### PR TITLE
Exclude Stone of Agony from hints if it is needed to get hints

### DIFF
--- a/HintList.py
+++ b/HintList.py
@@ -380,4 +380,6 @@ def hintExclusions(world):
         exclusions.append('Shadow Temple Hidden Floormaster Chest')
     else:
         exclusions.append('Shadow Temple MQ Bomb Flower Chest')
+    if world.hints == 'agony':
+        exclusions.append('Stone of Agony')
     return exclusions


### PR DESCRIPTION
If Stone of Agony is needed to get hints from gossip stones, then they should not tell you where it is (since you must already have it to get the hint in the first place). This adds the Stone of Agony as a hint exclusion in that case, removing a useless hint.